### PR TITLE
fix: rect 的圆角和阴影一起设置的冲突

### DIFF
--- a/lib/pen.js
+++ b/lib/pen.js
@@ -254,7 +254,7 @@ export default class Painter {
         break;
     }
     this.ctx.rotate(angle);
-    if (!notClip && view.css && view.css.borderRadius) {
+    if (!notClip && view.css && view.css.borderRadius && view.type !== 'rect') {
       this._doClip(view.css.borderRadius, width, height);
     }
     this._doShadow(view);
@@ -489,7 +489,18 @@ export default class Painter {
     } else {
       this.ctx.setFillStyle(view.css.color);
     }
-    this.ctx.fillRect(-(width / 2), -(height / 2), width, height);
+    const borderRadius = view.css.borderRadius
+    const r = borderRadius ? Math.min(borderRadius.toPx(), width / 2, height / 2) : 0;
+    this.ctx.beginPath();
+    this.ctx.arc(-width / 2 + r, -height / 2 + r, r, 1 * Math.PI, 1.5 * Math.PI); //左上角圆弧
+    this.ctx.lineTo(width / 2 - r, -height / 2);
+    this.ctx.arc(width / 2 - r, -height / 2 + r, r, 1.5 * Math.PI, 2 * Math.PI); // 右上角圆弧
+    this.ctx.lineTo(width / 2, height / 2 - r);
+    this.ctx.arc(width / 2 - r, height / 2 - r, r, 0, 0.5 * Math.PI); // 右下角圆弧
+    this.ctx.lineTo(-width / 2 + r, height / 2);
+    this.ctx.arc(-width / 2 + r, height / 2 - r, r, 0.5 * Math.PI, 1 * Math.PI); // 左下角圆弧
+    this.ctx.closePath();
+    this.ctx.fill();
     this.ctx.restore();
     this._doBorder(view, width, height);
   }


### PR DESCRIPTION
## related issue
https://github.com/Kujiale-Mobile/Painter/issues/155

现在对于 type:'rect' 可以一起同时设置 shadow 和 borderRadius 了